### PR TITLE
Add download button for boiler report

### DIFF
--- a/src/app/reports/boiler-inspection/preview/[boilerId]/components/download-button.tsx
+++ b/src/app/reports/boiler-inspection/preview/[boilerId]/components/download-button.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import {
+  ProgressDownloadDialog,
+  ProgressDownloadDialogRef,
+} from '@inspetor/components/progress-download-dialog'
+import { Button } from '@inspetor/components/ui/button'
+import { DownloadCloud } from 'lucide-react'
+import { useParams } from 'next/navigation'
+import { useRef } from 'react'
+
+type DownloadButtonProps = {
+  type: 'boiler' | 'manometer' | 'valve'
+}
+
+export function DownloadButton({ type: reportType }: DownloadButtonProps) {
+  const { boilerId } = useParams<{ boilerId: string }>()
+  const progressDownloadDialogRef = useRef<ProgressDownloadDialogRef | null>(
+    null,
+  )
+
+  async function generatePDF() {
+    progressDownloadDialogRef.current?.open()
+
+    await progressDownloadDialogRef.current?.generatePDF(boilerId, reportType)
+  }
+
+  return (
+    <>
+      <Button variant="inspetor-blue" onClick={generatePDF}>
+        Baixar Relatório <DownloadCloud className="size-4" />
+      </Button>
+      <ProgressDownloadDialog ref={progressDownloadDialogRef} />
+    </>
+  )
+}

--- a/src/app/reports/boiler-inspection/preview/[boilerId]/page.tsx
+++ b/src/app/reports/boiler-inspection/preview/[boilerId]/page.tsx
@@ -158,7 +158,7 @@ export default async function PreviewBoilerPage({
   const currentYear = reportCreatedAt.getFullYear()
 
   return (
-    <Container className="w-screen max-h-screen pb-4" id="preview-valve-page">
+    <Container className="w-screen max-h-screen pb-4" id="preview-boiler-page">
       <section className="w-full flex overflow-x-hidden overflow-y-clip items-start justify-start">
         <div className="w-full relative flex flex-col h-full justify-between col-span-6">
           <div className="w-full relative">

--- a/src/app/reports/boiler-inspection/preview/[boilerId]/page.tsx
+++ b/src/app/reports/boiler-inspection/preview/[boilerId]/page.tsx
@@ -55,6 +55,7 @@ import { notFound } from 'next/navigation'
 import { Fragment } from 'react'
 
 import { Aside } from './components/aside'
+import { DownloadButton } from './components/download-button'
 import { Nrs, NrsContainer } from './components/nrs-container'
 import { PageContainer } from './components/page-container'
 import { PageInfoContainer } from './components/page-info-container'
@@ -213,14 +214,12 @@ export default async function PreviewBoilerPage({
       {!isDownload && (
         <div className="fixed top-4 left-4 space-x-4">
           <BackButton />
-          {/* <DownloadButton /> */}
+          <DownloadButton type="boiler" />
         </div>
       )}
       {!isDownload && <ScrollBar orientation="vertical" />}
 
-      <Spacer />
-
-      <PageContainer breakPage={false}>
+      <PageContainer>
         <h2 className="text-3xl font-semibold mt-10">Relatório de inspeção</h2>
 
         <span className="w-full font-bold italic tracking-tight text-sm">
@@ -1807,9 +1806,7 @@ export default async function PreviewBoilerPage({
             )
           })}
         </NrsContainer>
-      </PageContainer>
 
-      <PageContainer>
         <div className="w-full">
           <PageSubTitle>observações</PageSubTitle>
           <div className="w-full h-fit min-h-24 border border-black p-4">

--- a/src/components/progress-download-dialog.tsx
+++ b/src/components/progress-download-dialog.tsx
@@ -84,13 +84,13 @@ const ProgressDownloadDialog = forwardRef(function ProgressDownloadDialog(
 
     try {
       setIsGeneratingPDF(true)
-      let reportAPiUrl = `/generate/calibration/pdf?report_id=${reportId}&calibration_type=${reportType}`
+      let reportApiUrl = `/generate/calibration/pdf?report_id=${reportId}&calibration_type=${reportType}`
 
       if (reportType === 'boiler') {
-        reportAPiUrl = `/generate/boiler-report/pdf?report_id=${reportId}`
+        reportApiUrl = `/generate/boiler-report/pdf?report_id=${reportId}`
       }
 
-      const response = await axiosApi.get(reportAPiUrl, {
+      const response = await axiosApi.get(reportApiUrl, {
         signal: signalController.signal,
       })
 

--- a/src/components/progress-download-dialog.tsx
+++ b/src/components/progress-download-dialog.tsx
@@ -84,12 +84,15 @@ const ProgressDownloadDialog = forwardRef(function ProgressDownloadDialog(
 
     try {
       setIsGeneratingPDF(true)
-      const response = await axiosApi.get(
-        `/generate/calibration/pdf?report_id=${reportId}&calibration_type=${reportType}`,
-        {
-          signal: signalController.signal,
-        },
-      )
+      let reportAPiUrl = `/generate/calibration/pdf?report_id=${reportId}&calibration_type=${reportType}`
+
+      if (reportType === 'boiler') {
+        reportAPiUrl = `/generate/boiler-report/pdf?report_id=${reportId}`
+      }
+
+      const response = await axiosApi.get(reportAPiUrl, {
+        signal: signalController.signal,
+      })
 
       setLogs((prevLogs) => [
         ...prevLogs,


### PR DESCRIPTION
Introduce a download button that allows users to generate and download the boiler report as a PDF. This feature enhances user experience by providing direct access to important report data.